### PR TITLE
Fix postMessage exception if element.ContentWindow is destoyed vimeo#124

### DIFF
--- a/src/lib/postmessage.js
+++ b/src/lib/postmessage.js
@@ -28,7 +28,10 @@ export function parseMessageData(data) {
  * @return {void}
  */
 export function postMessage(player, method, params) {
-    if (!player.element.contentWindow.postMessage) {
+    // Under some circumstances this method can be
+    // called while the `player.element.contentWindow` is already destroyed
+    // and this throws an exception;
+    if (!player.element.contentWindow || !player.element.contentWindow.postMessage) {
         return;
     }
 

--- a/test/postmessage-test.js
+++ b/test/postmessage-test.js
@@ -11,6 +11,17 @@ test('parseMessageData parses strings', (t) => {
     t.deepEqual(parseMessageData('{ "method": "getColor" }'), { method: 'getColor' });
 });
 
+test('postMessage doesn\'t fail if contentWindow is null', (t) => {
+    const player = {
+        element: {
+            contentWindow: null
+        },
+        origin: 'playerOrigin'
+    };
+
+    postMessage(player, 'testMethod');
+});
+
 test('postMessage called correctly with just a method', (t) => {
     const postMessageSpy = sinon.spy();
     const player = {


### PR DESCRIPTION
Add an extra check if contentWindow is available since in some cases postMessage method is called when player.element.contentWindow is destroyed.
Fix copied from #124